### PR TITLE
Feature: ended class status

### DIFF
--- a/features/classes_listing.feature
+++ b/features/classes_listing.feature
@@ -8,7 +8,7 @@ Feature:
         And user "Stefano" attends to class "Programming 101"
         When I open a list of classes
         Then I see 1st available class "topic" is "Programming 101"
-        And I see 1st available class "status" is "booked"
+        And I see 1st available class "status" is "ended"
         And I see 1st available class "startsAt" is "2020-01-01"
         And I see that "Stefano" is attending to "Programming 101"
 
@@ -16,7 +16,7 @@ Feature:
         Given there is a class "Programming 101" starting at "2020-01-01"
         And nobody attends to class "Programming 101"
         When I open a list of classes
-        And I see 1st available class "status" is "scheduled"
+        And I see 1st available class "status" is "cancelled"
 
     Scenario: List of classes doesn't show students' email addresses
         Given there is a class "Programming 101" starting at "2020-01-01"

--- a/src/Entity/Klass.php
+++ b/src/Entity/Klass.php
@@ -20,6 +20,9 @@ class Klass
     const FULL = 'full';
 
     const MAXIMUM_CAPACITY = 4;
+    const DURATION = 'PT1H'; // \DateInterval format
+    const CANCELLATION_DEADLINE = 'P2D'; // \DateInterval format
+
     /**
      * @ORM\Id()
      * @ORM\GeneratedValue()
@@ -124,7 +127,7 @@ class Klass
 
             return self::BOOKED;
         } else {
-            if ($this->startsAt()->diff(new \DateTimeImmutable())->days < 2) {
+            if ($this->startsAt->sub(new \DateInterval(self::CANCELLATION_DEADLINE)) <= new \DateTimeImmutable()) {
                 return self::CANCELLED;
             }
 

--- a/src/Entity/Klass.php
+++ b/src/Entity/Klass.php
@@ -18,6 +18,7 @@ class Klass
     const BOOKED = 'booked';
     const CANCELLED = 'cancelled';
     const FULL = 'full';
+    const ENDED = 'ended';
 
     const MAXIMUM_CAPACITY = 4;
     const DURATION = 'PT1H'; // \DateInterval format
@@ -121,7 +122,9 @@ class Klass
     public function status(): string
     {
         if ($this->students()->count()) {
-            if ($this->students()->count() >= 4) {
+            if ($this->startsAt->add(new \DateInterval(self::DURATION)) <= new \DateTimeImmutable('now')) {
+                return self::ENDED;
+            } elseif ($this->students()->count() >= 4) {
                 return self::FULL;
             }
 

--- a/tests/Classes/KlassTest.php
+++ b/tests/Classes/KlassTest.php
@@ -19,9 +19,9 @@ class KlassTest extends TestCase
     }
 
     /** @dataProvider studentsAndKlassStatuses */
-    public function testKlassStatus(int $numberOfAttendingStudents, string $expectedStatus)
+    public function testKlassIsFullWhenReaches4Students(int $numberOfAttendingStudents, string $expectedStatus)
     {
-        $klass = new Klass('Class topic', new \DateTimeImmutable('2013-04-27 17:00'));
+        $klass = new Klass('Class topic', new \DateTimeImmutable('+3 days'));
         for ($i = 0; $i < $numberOfAttendingStudents; ++$i) {
             $klass->enroll(new User());
         }

--- a/tests/Classes/KlassTest.php
+++ b/tests/Classes/KlassTest.php
@@ -48,4 +48,29 @@ class KlassTest extends TestCase
         $this->expectException(StudentEnrolledToFullKlassException::class);
         $klass->enroll(new User()); //too much
     }
+
+    /** @dataProvider studentsTimesAndKlassStatuses */
+    public function testKlassHasEndedStatusWhenItHadAttendeesAndItIsFinished(
+        string $studentCount,
+        string $startedAt,
+        string $expectedStatus
+    ) {
+        $klass = new Klass('Class topic', new \DateTimeImmutable($startedAt));
+        for ($i = 0; $i < $studentCount; ++$i) {
+            $klass->enroll(new User());
+        }
+        $this->assertEquals($expectedStatus, $klass->status());
+    }
+    public function studentsTimesAndKlassStatuses(): array
+    {
+        return [
+            [0, '+3 days', Klass::SCHEDULED],
+            [0, '+1 day', Klass::CANCELLED],
+            [0, '60 minutes ago', Klass::CANCELLED],
+            [0, '10 days ago', Klass::CANCELLED],
+            [1, '59 minutes ago', Klass::BOOKED],
+            [4, '59 minutes ago', Klass::FULL],
+            [1, '60 minutes ago', Klass::ENDED],
+        ];
+    }
 }


### PR DESCRIPTION
I know this is probably not what you expected, since I've removed a "status" field from the Klass in previous pull request, but since there's no known real case for this status, I think this solution is sufficient ;-)

In other case when there would be a need to store Klasse's status somewhere in the database I'd do it with some kind of CRON and worker updating it every hour or so.